### PR TITLE
Fixed formatting error bug

### DIFF
--- a/transcriptParse.py
+++ b/transcriptParse.py
@@ -14,26 +14,25 @@ def parseTranscript(inputLines, outputFile, justify = True, length = 105):
         data = [""] + [line.decode("utf8") for line in inputLines]
         
     lines = [""]
-
+    line_num = 1
     for i in range(len(data)):
-        if (i % 4 == 3 and data[1] == "1") or (i % 3 == 2 and data[1] != "1"):
-            line = data[i]
-            if line.find(">>") > -1:
-                lines[-1] = lines[-1] + "\n"
-            lines.append(line + " ")
-            
+        line = data[i]
+        if line.find("-->") > -1:
+            continue;
+        elif line.strip() == str(line_num):
+            line_num = line_num + 1;
+        else:
+            lines.append(line.replace('\n', '') + " ")
+    
     text = " ".join(lines)
     
     if justify:
         lines = leftJustify(text, length)
         
     for line in lines:
+        line = line.strip();
         if len(line) > 0:
-            if line[0] == " ":
-                line = line[1:]
-        line = line.replace(" >>", ">>")
-        line.replace("  ", " ")
-        outputFile.write(line.encode('ascii', 'ignore'))
+            outputFile.write(str(line.encode('ascii', 'ignore')))
 
 def leftJustify(text, lineLength):
     done = False


### PR DESCRIPTION
I modified the parseTranscript function to fix a formatting bug for the transcripts. The srt files have a '-->' instead of a '>>', and are numerically ordered, so my modification looks for those indicators to split lines.

This was tested on a Udacity course, 

From the current version (on Master), this is the output for a lesson:

*
b'In lesson one we introduced the  00:00:04,420 --> 00:00:09,430  3    IT could be a key tool, for  restructuring \n'b'healthcare to  00:00:20,440 --> 00:00:24,860  7     '
*

 this is the sample output after running it with my version:

*
b'In lesson one we introduced the  disconnect between what is required to    successfully manage the chronic'b'diseases  that drive most health care costs, and    the structure of the US  healthcare system.    We also'b'suggested that health  IT could be a key tool, for    restructuring healthcare to  help address these issues.'b"We'll review that in this lesson before  turning to the new US federal policies    to encourage adoption"b'of health  information technology, and    new models of patient centered care.'
*